### PR TITLE
Remove quotes from timestamp

### DIFF
--- a/genericJMXAPI.java
+++ b/genericJMXAPI.java
@@ -231,7 +231,7 @@ public class genericJMXAPI {
                 metricPayload.add(source);
                 metricPayload.add(mbean.boundary_metric_name);
                 metricPayload.add(mbean.displayValue);
-                metricPayload.add(String.valueOf(System.currentTimeMillis()));
+                metricPayload.add(System.currentTimeMillis());
                 metricsArray.add(metricPayload);
             }
 


### PR DESCRIPTION
API no longer allows a string for the timestamp.  Removed the type conversion.
